### PR TITLE
[FIX] bugfix

### DIFF
--- a/IsoSpec++/isoSpec++.cpp
+++ b/IsoSpec++/isoSpec++.cpp
@@ -151,6 +151,7 @@ inline int str_to_int(const string& s)
 
 Iso::Iso(const char* formula) :
 disowned(false),
+allDim(0),
 marginals(nullptr),
 modeLProb(0.0)
 {


### PR DESCRIPTION
- initialize allDim to zero also for the constructor from `const char*`,
  otherwise the variable is in an undefined state and will never get set
  properly. This leads to issues in memory allocation in the tabulator
  which uses this variable to compute the amount of memory necessary.