### PR TITLE
Compile msvs

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -21,6 +21,8 @@ If you wish to develop software using this library, you will also
 have to place the header files (*.hpp/*.h) somewhere your C/C++
 compiler can find them.
 
+On Windows, you should turn on the MANN_LIBRARY pre-processor directive when
+building the library.
 
 ------------------------------------------
 Building and installing the Python package

--- a/IsoSpec++/isoMath.cpp
+++ b/IsoSpec++/isoMath.cpp
@@ -7,19 +7,13 @@
  */
 
 #include <cmath>
-#include <unistd.h>
+#include <stdlib.h>     /* malloc, free, rand */
 #include "isoMath.h"
-
-#ifdef __MINGW32__
-	#include "mman.h"
-#else
-	#include <sys/mman.h>
-#endif
 
 const double pi = 3.14159265358979323846264338328;
 
 // 10M should be enough for everyone, right?
-double* g_lfact_table = reinterpret_cast<double*>(mmap(NULL, sizeof(double)*G_FACT_TABLE_SIZE, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0));
+double* g_lfact_table = reinterpret_cast<double*>(calloc(G_FACT_TABLE_SIZE, sizeof(double)));
 
 double RationalApproximation(double t)
 {

--- a/IsoSpec++/isoMath.cpp
+++ b/IsoSpec++/isoMath.cpp
@@ -7,13 +7,28 @@
  */
 
 #include <cmath>
-#include <stdlib.h>     /* malloc, free, rand */
 #include "isoMath.h"
+
+#if defined(__unix__) || defined(__unix) || \
+        (defined(__APPLE__) && defined(__MACH__))
+#include <sys/mman.h>
+#define GOT_MMAP 1
+#elif defined(__MINGW32__) || defined(_WIN32)
+#include "mman.h"
+#define GOT_MMAP 1
+#else
+#include <stdlib.h>     /* malloc, free, rand */
+#endif
 
 const double pi = 3.14159265358979323846264338328;
 
 // 10M should be enough for everyone, right?
+# if defined(GOT_MMAP)
+double* g_lfact_table = reinterpret_cast<double*>(mmap(NULL, sizeof(double)*G_FACT_TABLE_SIZE, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0));
+#else
 double* g_lfact_table = reinterpret_cast<double*>(calloc(G_FACT_TABLE_SIZE, sizeof(double)));
+#endif
+
 
 double RationalApproximation(double t)
 {

--- a/IsoSpec++/isoSpec++.cpp
+++ b/IsoSpec++/isoSpec++.cpp
@@ -111,7 +111,7 @@ inline void Iso::setupMarginals(const double* const * _isotopeMasses, const doub
 
 Iso::~Iso()
 {
-    if(not disowned)
+    if(!disowned)
     {
     if (marginals != nullptr)
         dealloc_table(marginals, dimNumber);
@@ -322,13 +322,13 @@ last_marginal(static_cast<SyncMarginal*>(PMs[dimNumber-1]))
     {
         counter[ii] = 0;
 
-        if(not marginalResults[ii]->inRange(0))
+        if(!marginalResults[ii]->inRange(0))
             empty = true;
     }
 
     marginalResults[dimNumber-1] = last_marginal;
     counter[dimNumber-1] = last_marginal->getNextConfIdx();
-    if(not last_marginal->inRange(counter[dimNumber-1]))
+    if(!last_marginal->inRange(counter[dimNumber-1]))
         empty = true;
 
 
@@ -337,7 +337,7 @@ last_marginal(static_cast<SyncMarginal*>(PMs[dimNumber-1]))
         maxConfsLPSum[ii] = maxConfsLPSum[ii-1] + marginalResults[ii]->getModeLProb();
 
 
-    if(not empty)
+    if(!empty)
     {
         recalc(dimNumber-1);
         counter[0]--;
@@ -432,7 +432,7 @@ Lcutoff(_threshold <= 0.0 ? std::numeric_limits<double>::lowest() : (_absolute ?
                                                         tabSize,
                                                         hashSize);
 
-        if(not marginalResults[ii]->inRange(0))
+        if(!marginalResults[ii]->inRange(0))
             empty = true;
     }
 
@@ -440,7 +440,7 @@ Lcutoff(_threshold <= 0.0 ? std::numeric_limits<double>::lowest() : (_absolute ?
     for(int ii=1; ii<dimNumber-1; ii++)
         maxConfsLPSum[ii] = maxConfsLPSum[ii-1] + marginalResults[ii]->getModeLProb();
 
-    if(not empty)
+    if(!empty)
     {
         recalc(dimNumber-1);
         counter[0]--;

--- a/IsoSpec++/isoSpec++.h
+++ b/IsoSpec++/isoSpec++.h
@@ -248,8 +248,8 @@ public:
     inline void setup_delta(double new_delta) { delta = new_delta; nextLayer(delta); };
     inline bool advanceToNextConfiguration() override final
     {
-        while (not advanceToNextConfiguration_internal())
-            if (not nextLayer(delta))
+        while (!advanceToNextConfiguration_internal())
+            if (!nextLayer(delta))
                 return false;
         std::cout << "Returning conf: " << counter[0] << " " << counter[1] << " " << partialLProbs[0] << std::endl;
         return true;

--- a/IsoSpec++/marginalTrek++.cpp
+++ b/IsoSpec++/marginalTrek++.cpp
@@ -90,12 +90,12 @@ Conf initialConfigure(const int atomCnt, const int isotopeNo, const double* prob
         modified = false;
         for(int ii = 0; ii<isotopeNo; ii++)
         for(int jj = 0; jj<isotopeNo; jj++)
-            if(ii != jj and res[ii] > 0)
+            if(ii != jj && res[ii] > 0)
         {
             res[ii]--;
             res[jj]++;
             NLP = unnormalized_logProb(res, lprobs, isotopeNo);
-            if(NLP>LP or (NLP==LP and ii>jj))
+            if(NLP>LP || (NLP==LP && ii>jj))
             {
                 modified = true;
             LP = NLP;
@@ -204,7 +204,7 @@ smallest_lprob(other.smallest_lprob)
 
 Marginal::~Marginal()
 {
-    if(not disowned)
+    if(!disowned)
     {
         delete[] atom_masses;
         delete[] atom_lProbs;
@@ -363,12 +363,12 @@ allocator(isotopeNo, tabSize)
         idx++;
         for(unsigned int ii = 0; ii < isotopeNo; ii++ )
             for(unsigned int jj = 0; jj < isotopeNo; jj++ )
-                if( ii != jj and currentConf[jj] > 0)
+                if( ii != jj && currentConf[jj] > 0)
                 {
                     currentConf[ii]++;
                     currentConf[jj]--;
 
-                    if (visited.count(currentConf) == 0 and logProb(currentConf) >= lCutOff)
+                    if (visited.count(currentConf) == 0 && logProb(currentConf) >= lCutOff)
                     {
                         visited.insert(currentConf);
                         configurations.push_back(allocator.makeCopy(currentConf));
@@ -438,7 +438,7 @@ bool LayeredMarginal::extend(double new_threshold)
     double lpc, opc;
 
     Conf currentConf;
-    while(not fringe.empty())
+    while(!fringe.empty())
     {
         currentConf = fringe.back();
         fringe.pop_back();
@@ -453,15 +453,15 @@ bool LayeredMarginal::extend(double new_threshold)
             configurations.push_back(currentConf);
             for(unsigned int ii = 0; ii < isotopeNo; ii++ )
                 for(unsigned int jj = 0; jj < isotopeNo; jj++ )
-                    if( ii != jj and currentConf[jj] > 0 )
+                    if( ii != jj && currentConf[jj] > 0 )
                     {
                         currentConf[ii]++;
                         currentConf[jj]--;
 
                         lpc = logProb(currentConf);
 
-                        if (visited.count(currentConf) == 0 and lpc < current_threshold and
-                            (opc > lpc or (opc == lpc and ii > jj)))
+                        if (visited.count(currentConf) == 0 && lpc < current_threshold &&
+                            (opc > lpc || (opc == lpc && ii > jj)))
                         {
                             Conf nc = allocator.makeCopy(currentConf);
                             visited.insert(nc);

--- a/IsoSpec++/marginalTrek++.h
+++ b/IsoSpec++/marginalTrek++.h
@@ -100,7 +100,7 @@ public:
     inline bool probeConfigurationIdx(int idx)
     {
         while(current_count <= idx)
-            if(not add_next_conf())
+            if(!add_next_conf())
                 return false;
         return true;
     }
@@ -171,7 +171,7 @@ public:
     inline unsigned int getNextConfIdxwMass(double mmin, double mmax)
     {
     	unsigned int local = counter.fetch_add(1, std::memory_order_relaxed);
-	while(local < no_confs and (mmin > masses[local] or mmax < masses[local]))
+	while(local < no_confs && (mmin > masses[local] || mmax < masses[local]))
 	    local = counter.fetch_add(1, std::memory_order_relaxed);
 	return local;
     }

--- a/IsoSpec++/operators.h
+++ b/IsoSpec++/operators.h
@@ -52,7 +52,7 @@ public:
 
     inline bool operator()(const int* conf1, const int* conf2) const
     {
-        return not memcmp(conf1, conf2, size);
+        return !memcmp(conf1, conf2, size);
     }
 };
 

--- a/IsoSpec++/spectrum.cpp
+++ b/IsoSpec++/spectrum.cpp
@@ -60,7 +60,7 @@ SinglePointFunctionalKernel::SinglePointFunctionalKernel() {}
 
 double SinglePointFunctionalKernel::getMass(double bucketStart, double bucketEnd)
 {
-	if(bucketStart <= 0.0 and 0.0 < bucketEnd)
+	if(bucketStart <= 0.0 && 0.0 < bucketEnd)
 		return 1.0;
 	return 0.0;
 }

--- a/IsoSpec++/summator.h
+++ b/IsoSpec++/summator.h
@@ -119,7 +119,7 @@ public:
     inline void add(double what)
     {
         double previous = sum.load(std::memory_order_relaxed);
-        while(not sum.compare_exchange_weak(previous, previous+what, std::memory_order_relaxed)) {};
+        while(!sum.compare_exchange_weak(previous, previous+what, std::memory_order_relaxed)) {};
     }
     inline double get()
     {


### PR DESCRIPTION
Several fixes to compile with MSVS

- replace not/or/and with ! / || / &&
- remove Unix-specific header, repace with calloc