### PR TITLE
[BUG] bugreport memory

### DIFF
--- a/tests/C++/Makefile
+++ b/tests/C++/Makefile
@@ -6,6 +6,9 @@ TESTMEMFLAGS= $(TESTFLAGS) -fsanitize=memory
 TESTADDRFLAGS= $(TESTFLAGS) -fsanitize=address
 LLVMTESTFLAGS= -fsanitize=dataflow,cfi,safe-stack
 CXXFLAGS=-std=c++11 -Wall -I../../IsoSpec++ -Wextra -pedantic -lpthread
+SHARED_FLAGS=-L../../IsoSpec++
+LINK_FLAGS=-Wl,-rpath,../../IsoSpec++ ../../IsoSpec++/libIsoSpec++.so
+
 SRCFILES=../../IsoSpec++/unity-build.cpp
 
 all: testcc
@@ -15,6 +18,12 @@ testcc:
 	clang++ $(CXXFLAGS) $(OPTFLAGS) $(SRCFILES) from_formula.cpp -o ./from_formula_clang
 	g++ $(CXXFLAGS) $(OPTFLAGS) $(SRCFILES) from_formula.cpp -o ./from_formula_gcc
 	g++-5 $(CXXFLAGS) $(OPTFLAGS) $(SRCFILES) from_formula.cpp -o ./from_formula_gcc-5
+
+memleak:
+	clang++ $(SHARED_FLAGS) $(CXXFLAGS) $(DEBUGFLAGS) $(TESTADDRFLAGS) -lIsoSpec++ memleak.cpp -o ./memleak-clang $(LINK_FLAGS)
+	g++ $(SHARED_FLAGS) $(CXXFLAGS) $(DEBUGFLAGS) $(TESTADDRFLAGS) -pthread -lIsoSpec++ memleak.cpp -o ./memleak-gcc $(LINK_FLAGS)
+	clang++ $(SHARED_FLAGS) $(CXXFLAGS) $(OPTFLAGS) -lIsoSpec++ memleak.cpp -o ./memleak-clang-opt $(LINK_FLAGS)
+	g++ $(SHARED_FLAGS) $(CXXFLAGS) $(OPTFLAGS) -lIsoSpec++ -pthread memleak.cpp -o ./memleak-gcc-opt $(LINK_FLAGS)
 
 test:
 	clang++ $(CXXFLAGS) $(DEBUGFLAGS) $(TESTADDRFLAGS) $(SRCFILES) test.cpp -o ./test-clang

--- a/tests/C++/memleak.cpp
+++ b/tests/C++/memleak.cpp
@@ -1,0 +1,57 @@
+#include <iostream>
+#include <string>
+#include <cassert>
+
+#include "isoSpec++.h"
+#include "tabulator.cpp"
+
+int main()
+{
+  std::string formula = "C520H817N139O147";
+
+  int tabSize = 1000;
+  int hashSize = 1000;
+  double threshold = 0.01;
+  bool absolute = false;
+
+  // Do some stress testing of the library...
+  int sum = 0;
+  for (size_t k = 0; k < 5e6; k++)
+  {
+
+    // Run threshold with 1e-2
+    {
+      Iso* iso = new Iso(formula.c_str());
+      IsoThresholdGenerator* generator = new IsoThresholdGenerator(std::move(*iso), threshold, absolute, tabSize, hashSize); 
+      Tabulator<IsoThresholdGenerator>* tabulator = new Tabulator<IsoThresholdGenerator>(generator, true, true, false, true); 
+      int size = tabulator->confs_no();
+      sum += size;
+      // std::cout << size << std::endl;
+
+      delete generator;
+      delete tabulator;
+    }
+
+
+  }
+  // with debug on:
+  // 1e4 :   1.18user 0.10system 0:01.28elapsed 99%CPU (0avgtext+0avgdata 287836maxresident)k
+  // 1e5 :  11.70user 0.14system 0:11.95elapsed 99%CPU (0avgtext+0avgdata 295528maxresident)k
+  // 5e5 :  58.12user 0.33system 0:58.57elapsed 99%CPU (0avgtext+0avgdata 337772maxresident)k
+  // 1e6 : 117.65user 0.20system 1:57.86elapsed 99%CPU (0avgtext+0avgdata 392104maxresident)k
+
+  // gcc-opt
+  // 1e5 :   1.66user 0.00system 0:01.66elapsed 99%CPU (0avgtext+0avgdata  9884maxresident)k
+  // 1e6 :  16.21user 0.00system 0:16.22elapsed 99%CPU (0avgtext+0avgdata  66120maxresident)k
+  // 5e6 :  86.24user 0.17system 1:26.41elapsed 99%CPU (0avgtext+0avgdata 316224maxresident)k
+  //
+  // clang-opt
+  // 1e5 :   1.66user 0.00system 0:01.66elapsed 99%CPU (0avgtext+0avgdata  10060maxresident)k
+  // 1e6 :  16.79user 0.02system 0:16.81elapsed 99%CPU (0avgtext+0avgdata  66192maxresident)k
+  // 5e6 : 103.04user 0.17system 1:43.24elapsed 99%CPU (0avgtext+0avgdata 316348maxresident)k
+  //
+  //
+
+}
+
+


### PR DESCRIPTION
We have been worried a bit about the potential of memory leaks in the IsoSpec algorithms, so I did some benchmarking and what I found was that in a tight loop there seems to be leaks of memory. I hope that I am doing this correctly but in my understanding, this should clean up all memory when run in a loop:

```
      Iso* iso = new Iso(formula.c_str());
      IsoThresholdGenerator* generator = new IsoThresholdGenerator(std::move(*iso), threshold, absolute, tabSize, hashSize); 
      Tabulator<IsoThresholdGenerator>* tabulator = new Tabulator<IsoThresholdGenerator>(generator, true, true, false, true); 
      delete generator;
      delete tabulator;
```

to reproduce, run 

```
$ make memleak && /usr/bin/time ./memleak-clang-opt 
88.28user 0.18system 1:28.47elapsed 99%CPU (0avgtext+0avgdata 316356maxresident)k
0inputs+0outputs (0major+78337minor)pagefaults 0swaps
```

as documented, what is worrying is that memory keeps constantly increasing the longer the loop is run which is concerning.