### PR TITLE
[BUG] fixes bug in subisotope generator

### DIFF
--- a/IsoSpec++/marginalTrek++.cpp
+++ b/IsoSpec++/marginalTrek++.cpp
@@ -351,8 +351,11 @@ allocator(isotopeNo, tabSize)
     Conf currentConf = allocator.makeCopy(mode_conf);
     if(logProb(currentConf) >= lCutOff)
     {
-        configurations.push_back(allocator.makeCopy(currentConf));
-        visited.insert(currentConf);
+        // create a copy and store a ptr to the *same* copy in both structures
+        // (save some space and time)
+        auto tmp = allocator.makeCopy(currentConf);
+        configurations.push_back(tmp);
+        visited.insert(tmp);
     }
 
     unsigned int idx = 0;
@@ -370,8 +373,12 @@ allocator(isotopeNo, tabSize)
 
                     if (visited.count(currentConf) == 0 && logProb(currentConf) >= lCutOff)
                     {
-                        visited.insert(currentConf);
-                        configurations.push_back(allocator.makeCopy(currentConf));
+                        // create a copy and store a ptr to the *same* copy in
+                        // both structures (save some space and time)
+                        auto tmp = allocator.makeCopy(currentConf);
+                        visited.insert(tmp);
+                        configurations.push_back(tmp);
+                        // std::cout << " V: "; for (auto it : visited) std::cout << it << " "; std::cout << std::endl;
                     }
 
                     currentConf[ii]--;

--- a/IsoSpec++/tabulator.h
+++ b/IsoSpec++/tabulator.h
@@ -10,7 +10,7 @@ private:
     double* _lprobs;
     double* _probs;
     int*    _confs;
-    int     _confs_no;
+    int64_t     _confs_no;
 public:
     Tabulator(T* generator,
               bool get_masses, bool get_probs,
@@ -22,7 +22,7 @@ public:
     inline double*   lprobs()   { return _lprobs; };
     inline double*   probs()    { return _probs; };
     inline int*      confs()    { return _confs; };
-    inline int       confs_no() { return _confs_no; };
+    inline int64_t       confs_no() { return _confs_no; };
 };
 
 #endif  // __TABULATOR_H__

--- a/tests/C++/Makefile
+++ b/tests/C++/Makefile
@@ -39,3 +39,6 @@ la:
 
 IsoThresholdGenerator:
 	clang++ -std=c++11 IsoThresholdGenerator.cpp -o IsoThresholdGenerator -lpthread
+
+nr_conf:
+	clang++ -std=c++11 nr_conf.cpp -o nr_conf -lpthread

--- a/tests/C++/nr_conf.cpp
+++ b/tests/C++/nr_conf.cpp
@@ -1,0 +1,111 @@
+#include <iostream>
+#include <string>
+#include <cassert>
+
+#include "../../IsoSpec++/unity-build.cpp"
+
+int main()
+{
+  std::string formula = "C100";
+
+  int tabSize = 1000;
+  int hashSize = 1000;
+  double threshold = 0.01;
+  bool absolute = false;
+
+  threshold = 1e-2;
+  {
+    Iso* iso = new Iso(formula.c_str());
+    IsoThresholdGenerator* generator = new IsoThresholdGenerator(std::move(*iso), threshold, absolute, tabSize, hashSize); 
+    Tabulator<IsoThresholdGenerator>* tabulator = new Tabulator<IsoThresholdGenerator>(generator, true, true, false, true); 
+    int64_t size = tabulator->confs_no();
+    std::cout << size << std::endl;
+
+    delete iso;
+    delete generator;
+    delete tabulator;
+  }
+
+
+  threshold = 1e-200;
+  {
+    Iso* iso = new Iso(formula.c_str());
+    IsoThresholdGenerator* generator = new IsoThresholdGenerator(std::move(*iso), threshold, absolute, tabSize, hashSize); 
+    Tabulator<IsoThresholdGenerator>* tabulator = new Tabulator<IsoThresholdGenerator>(generator, true, true, false, true); 
+    int64_t size = tabulator->confs_no();
+    std::cout << size << std::endl;
+
+    delete iso;
+    delete generator;
+    delete tabulator;
+  }
+
+  formula = "C520H817N139O147S8";
+
+  threshold = 1e-10;
+  {
+    Iso* iso = new Iso(formula.c_str());
+    IsoThresholdGenerator* generator = new IsoThresholdGenerator(std::move(*iso), threshold, absolute, tabSize, hashSize); 
+    Tabulator<IsoThresholdGenerator>* tabulator = new Tabulator<IsoThresholdGenerator>(generator, true, true, false, true); 
+    int64_t size = tabulator->confs_no();
+    std::cout << size << std::endl;
+
+    delete iso;
+    delete generator;
+    delete tabulator;
+  }
+
+  threshold = 1e-50;
+  {
+    Iso* iso = new Iso(formula.c_str());
+    IsoThresholdGenerator* generator = new IsoThresholdGenerator(std::move(*iso), threshold, absolute, tabSize, hashSize); 
+    Tabulator<IsoThresholdGenerator>* tabulator = new Tabulator<IsoThresholdGenerator>(generator, true, true, false, true); 
+    int64_t size = tabulator->confs_no();
+    std::cout << size << std::endl;
+
+    delete iso;
+    delete generator;
+    delete tabulator;
+  }
+
+  threshold = 1e-100;
+  {
+    Iso* iso = new Iso(formula.c_str());
+    IsoThresholdGenerator* generator = new IsoThresholdGenerator(std::move(*iso), threshold, absolute, tabSize, hashSize); 
+    Tabulator<IsoThresholdGenerator>* tabulator = new Tabulator<IsoThresholdGenerator>(generator, true, true, false, true); 
+    int64_t size = tabulator->confs_no();
+    std::cout << size << std::endl;
+
+    delete iso;
+    delete generator;
+    delete tabulator;
+  }
+
+#if 0
+  threshold = 1e-200;
+  {
+    Iso* iso = new Iso(formula.c_str());
+    IsoThresholdGenerator* generator = new IsoThresholdGenerator(std::move(*iso), threshold, absolute, tabSize, hashSize); 
+    Tabulator<IsoThresholdGenerator>* tabulator = new Tabulator<IsoThresholdGenerator>(generator, true, true, false, true); 
+    int64_t size = tabulator->confs_no();
+    std::cout << size << std::endl;
+
+    delete iso;
+    delete generator;
+    delete tabulator;
+  }
+
+  threshold = 1e-300;
+  {
+    Iso* iso = new Iso(formula.c_str());
+    IsoThresholdGenerator* generator = new IsoThresholdGenerator(std::move(*iso), threshold, absolute, tabSize, hashSize); 
+    Tabulator<IsoThresholdGenerator>* tabulator = new Tabulator<IsoThresholdGenerator>(generator, true, true, false, true); 
+    int64_t size = tabulator->confs_no();
+    std::cout << size << std::endl;
+
+    delete iso;
+    delete generator;
+    delete tabulator;
+  }
+#endif
+}


### PR DESCRIPTION
I think I found a bug in the subisotope generator that would lead to the calculation of the wrong number of subisotope configuration. Specifically it lead to the calculation of fewer isotopic configuration than necessary as illustrate in the test file. 

# Rationale and Analysis

At the moment, a ptr to the *current* configuration was stored in `visited`  which meant the *same* ptr was stored N times instead of storing N different configurations. This meant that `visited.count(currentConf)` would not work reliably. Since this is the abort condition in the loop of  `PrecalculatedMarginal::PrecalculatedMarginal`, the loop aborted too early.

Actually, it is surprising that it worked at all since the *same* data was stored in all entries of `visited` -- but with a different hash each time since at the time of insertion the correct data was present behind the ptr, however later when `currentConf` changted, the data also changed.

So this was really broken but amazingly kind of worked due to the `unordered_set` probably only using the hashes for its `count` function and never actually comparing the data (which was actually always the same!). However, depending on the implementation or the hash function, at some point some comparison was made and then noticed that all the data was actually the same. So it is just a matter of time until this breaks and leads to an early abort in the `PrecalculatedMarginal::PrecalculatedMarginal` function, which means not enough subisotopologues were calculated.

# Impact
Since the bug relies on implementation-specific behavior of `std::unordered_map` it is hard to say how strong the impact is since it will depend on platform and implementation. However, it is clear that wrong numbers will be calculated. From my tests below, I see a anything from 20% error to a 2.3-fold error in the correct number of subisotopologues. One question remains is whether this could affect the conclusions from the paper (I hope not).

# Fix
Simply store a copy of the current configuration in `visited`. I chose to make a single copy and store it both `visited` and `configurations` since those data structures are read only and there is no need to use up extra memory.

**ATTENTION**: I did not check whether the same bug is present elsewhere in the code and I only tested the fix for `IsoThresholdGenerator`.

# Test

Testing is somewhat hard since I did not calculate what the correct number of subisotopologues really is, the only one I can say this for sure is that for `C100` at very high threshold we should have 101 subisotopologues. MSVS and clang on OSX did not produce that result and we therefore found the bug. However, we also found that on other formulae a smaller number of subisotopologues was calculated (e.g. for insulin this happened above 1e-100). 

- formula = "C100"; -> calculate threshold 1e-2
- formula = "C100"; -> calculate threshold 1e-200
- formula = "C520H817N139O147S8"; -> calculate threshold 1e-10;
- formula = "C520H817N139O147S8"; -> calculate threshold 1e-50;
- formula = "C520H817N139O147S8"; -> calculate threshold 1e-100;

current output:

```
-- MSVC
C:\openms\source\IsoSpec\IsoSpec++\build_debug>nr_conf.exe
6
97
89751
111619623
1063898204

-- Linux clang++
6
101
90419
135147222
2480098209
49.54user 2.03system 0:51.61elapsed 99%CPU (0avgtext+0avgdata 7606244maxresident)k
0inputs+0outputs (0major+1907998minor)pagefaults 0swaps
```

output after bugfix

```
-- Linux clang++
$ /usr/bin/time ./nr_conf 
6
101
90419
135147222
2480155266
48.21user 1.89system 0:50.11elapsed 99%CPU (0avgtext+0avgdata 7606264maxresident)k
0inputs+0outputs (0major+1907999minor)pagefaults 0swaps

-- MSVC
C:\openms\source\IsoSpec\IsoSpec++\build_debug>nr_conf.exe
6
101
90419
135147222
2480155266
```

so the results for MSVC before (1063898204) and after (2480155266) show a 2.3x difference!

**Task**: we should have an independent calculation to verify that these numbers are now correct and there isnt some other bug in the code. 