### PR TITLE
[FIX] fix per docu

### DIFF
--- a/IsoSpec++/operators.h
+++ b/IsoSpec++/operators.h
@@ -58,7 +58,7 @@ public:
         // is not required by C and portable code should only depend on the sign of
         // the returned value.
         //                                          sacred man of memcmp.
-        return memcmp(conf1, conf2, size) != 0;
+        return memcmp(conf1, conf2, size) == 0;
     }
 };
 


### PR DESCRIPTION
- if the memory regions are equal, memcmp returns zero and we should
  return true