### PR TITLE
Implement raw strings for SyntaxError in Python3.12+

### DIFF
--- a/IsoSpecPy/IsoSpecPyOld.py
+++ b/IsoSpecPy/IsoSpecPyOld.py
@@ -34,6 +34,9 @@ except NameError:
 import re
 from .IsoSpecPy import IsoTotalProb, IsoThreshold
 
+DIGIT_PATTERN = re.compile(r"\d+")
+NON_DIGIT_PATTERN = re.compile(r"\D+")
+
 class IsoSpec():
     def __init__(
                     self,
@@ -95,8 +98,8 @@ class IsoSpec():
     def IsoFromFormula(formula, cutoff, tabSize = 1000, hashSize = 1000, classId = None, method = 'threshold_relative', step = 0.25, trim = True):
         # It's much easier to just parse it in python than to use the C parsing function
         # and retrieve back into Python the relevant object sizes
-        symbols = re.findall("\D+", formula)
-        atom_counts = [int(x) for x in re.findall("\d+", formula)]
+        symbols = re.findall(NON_DIGIT_PATTERN, formula)
+        atom_counts = [int(x) for x in re.findall(DIGIT_PATTERN, formula)]
 
         if not len(symbols) == len(atom_counts):
             raise ValueError("Invalid formula")


### PR DESCRIPTION
Python Version: `3.12.8`
isospecpy: `2.2.1`

While working with IsoSpec and running the latest Python version, it seems there are a couple raw strings, or intended raw to be strings, which are causing `SyntaxError`. This PR should resolve these issues and allow for backwards/forwards compatibility

```
.venv/lib/python3.12/site-packages/_pytest/python.py:493: in importtestmodule
    mod = import_path(
.venv/lib/python3.12/site-packages/_pytest/pathlib.py:587: in import_path
    importlib.import_module(module_name)
/usr/local/lib/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1387: in _gcd_import
    ???
<frozen importlib._bootstrap>:1360: in _find_and_load
    ???
<frozen importlib._bootstrap>:1331: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:935: in _load_unlocked
    ???
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:184: in exec_module
    exec(co, module.__dict__)
tests/test_sequencing.py:8: in <module>
    from src import sequencing
src/sequencing/__init__.py:13: in <module>
    from src.sequencing import fragmentation, util
src/sequencing/fragmentation.py:6: in <module>
    from src.sequencing import util
src/sequencing/util.py:2: in <module>
    import IsoSpecPy
.venv/lib/python3.12/site-packages/IsoSpecPy/__init__.py:18: in <module>
    IsoSpecPy = CompatIsoWrapper()
.venv/lib/python3.12/site-packages/IsoSpecPy/__init__.py:12: in __init__
    from .IsoSpecPyOld import IsoSpec, IsoSpecify, IsoPlot
E     File "/home/herman/massmatrix/msp/.venv/lib/python3.12/site-packages/IsoSpecPy/IsoSpecPyOld.py", line 98
E       symbols = re.findall("\D+", formula)
E                            ^^^^^
E   SyntaxError: invalid escape sequence '\D'
```

```
.venv/lib/python3.12/site-packages/_pytest/python.py:493: in importtestmodule
    mod = import_path(
.venv/lib/python3.12/site-packages/_pytest/pathlib.py:587: in import_path
    importlib.import_module(module_name)
/usr/local/lib/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1387: in _gcd_import
    ???
<frozen importlib._bootstrap>:1360: in _find_and_load
    ???
<frozen importlib._bootstrap>:1331: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:935: in _load_unlocked
    ???
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:184: in exec_module
    exec(co, module.__dict__)
tests/test_sequencing.py:8: in <module>
    from src import sequencing
src/sequencing/__init__.py:13: in <module>
    from src.sequencing import fragmentation, util
src/sequencing/fragmentation.py:6: in <module>
    from src.sequencing import util
src/sequencing/util.py:2: in <module>
    import IsoSpecPy
.venv/lib/python3.12/site-packages/IsoSpecPy/__init__.py:18: in <module>
    IsoSpecPy = CompatIsoWrapper()
.venv/lib/python3.12/site-packages/IsoSpecPy/__init__.py:12: in __init__
    from .IsoSpecPyOld import IsoSpec, IsoSpecify, IsoPlot
E     File "/home/herman/massmatrix/msp/.venv/lib/python3.12/site-packages/IsoSpecPy/IsoSpecPyOld.py", line 99
E       atom_counts = [int(x) for x in re.findall("\d+", formula)]
E                                                 ^^^^^
E   SyntaxError: invalid escape sequence '\d'
```