### PR TITLE
Fix MXE cross-build and remove no more needed debian/copyright Comment.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ cmake_minimum_required(VERSION 3.12)
 ############################################################
 # Basic information about project
 
-project(IsoSpec VERSION 2.3.2
+project(IsoSpec VERSION 2.3.3
     DESCRIPTION "A program to calculate isotopic clusters"
     HOMEPAGE_URL "https://github.com/MatteoLacki/IsoSpec")
 

--- a/CMakeStuff/toolchains/mxe-toolchain-rusconi.cmake
+++ b/CMakeStuff/toolchains/mxe-toolchain-rusconi.cmake
@@ -13,6 +13,8 @@ set(MXE_SHIPPED_DLLS_DIR "${MXE_ROOT_DIR}/dll-set-for-packages")
 set(CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES ${HOME_DEVEL_DIR}/mxe/usr/x86_64-w64-mingw32.shared/include)
 set(CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES ${HOME_DEVEL_DIR}/mxe/usr/x86_64-w64-mingw32.shared/include)
 
+add_definitions(-D MANN_LIBRARY -D MXE)
+
 if(WIN32 OR _WIN32)
     message(STATUS "Building with WIN32 defined.")
 endif()
@@ -20,8 +22,8 @@ endif()
 ## We can build the package setup executable with this specific command.
 add_custom_target(
     dllinstall
-    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/IsoSpec++/libIsoSpec++.dll ${MXE_SHIPPED_DLLS_DIR}
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/src/IsoSpec++/libIsoSpec++.dll ${MXE_SHIPPED_DLLS_DIR}
     COMMENT "Build and copy the dll file to its MXE destination."
-    DEPENDS ${CMAKE_BINARY_DIR}/IsoSpec++/libIsoSpec++.dll
+    DEPENDS ${CMAKE_BINARY_DIR}/src/IsoSpec++/libIsoSpec++.dll
     VERBATIM
 )

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,11 +1,22 @@
+isospec (2.3.3-1) unstable; urgency=medium
+
+  * New upstream release.
+
+  * Fix cross-build in MXE cross-compilation environment.
+  * Remove no more needed comment in debian/copyright.
+
+ -- Filippo Rusconi <lopippo@debian.org>  Thu, 13 Nov 2025 14:26:01 +0100
+
 isospec (2.3.2-1) unstable; urgency=medium
+
+  * New upstream release.
 
   * Steer away from graphicsmagick and replace by librsvg2-bin for
     conversion of svg to png.
 
   * libisospec++-dev: Drop Multi-Arch: same (Janitor pull request).
 
- -- Filippo Rusconi <lopippo@debian.org>  Tue, 04 Nov 2025 19:05:21 +0100
+ -- Filippo Rusconi <lopippo@debian.org>  Wed, 05 Nov 2025 23:00:09 +0100
 
 isospec (2.3.1-2) unstable; urgency=medium
 

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,10 +1,6 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: libisospec
 Source: https://github.com/MatteoLacki/IsoSpec
-Comment: The upstream source tarball contains Windows dll files and
-    other documentation files that are regenerated using doxygen.
-    All these files are thereby not useful or appropriate for use as
-    source files. This violates DFSG §2.
 
 Files: *
 Copyright: 2015-2018 Michal Startek

--- a/debian/patches/library-version.patch
+++ b/debian/patches/library-version.patch
@@ -6,8 +6,8 @@ index d839ba8..3fa336b 100644
  ############################################################
  # Basic information about project
 
--project(IsoSpec VERSION 2.3.2
-+project(IsoSpec VERSION 2.3.2
+-project(IsoSpec VERSION 2.3.3
++project(IsoSpec VERSION 2.3.3
      DESCRIPTION "A program to calculate isotopic clusters"
      HOMEPAGE_URL "https://github.com/MatteoLacki/IsoSpec")
 

--- a/src/IsoSpec++/platform.h
+++ b/src/IsoSpec++/platform.h
@@ -96,7 +96,7 @@
 #define ISOSPEC_EXPORT_SYMBOL
 #endif
 
-#if defined(_WIN32) || defined(_WIN64)
+#if (defined(_WIN32) || defined(_WIN64)) && !defined(MXE)
 #define ISOSPEC_C_API __declspec(dllexport)
 #else
 #define ISOSPEC_C_API


### PR DESCRIPTION
Greetings, Matteo and Michal,

a few fixes for those willing to cross-build for Windows in Linux using the MXE environement (which we do :-).

No changes to your code.

Could you merge that to 2.3.2 and tag 2.3.3, please ?
Thank you so much!
Most sincerely,
Filippo